### PR TITLE
Promote direction methods, remove queueIn/Out on provider

### DIFF
--- a/src/Entity/SmsMessage.php
+++ b/src/Entity/SmsMessage.php
@@ -491,6 +491,7 @@ class SmsMessage extends ContentEntityBase implements SmsMessageInterface {
 
     $new = static::create();
     $new
+      ->setDirection($sms_message->getDirection())
       ->setAutomated($sms_message->isAutomated())
       ->setSenderNumber($sms_message->getSenderNumber())
       ->addRecipients($sms_message->getRecipients())

--- a/src/Entity/SmsMessage.php
+++ b/src/Entity/SmsMessage.php
@@ -229,7 +229,8 @@ class SmsMessage extends ContentEntityBase implements SmsMessageInterface {
    * {@inheritdoc}
    */
   public function setDirection($direction) {
-    return $this->set('direction', $direction);
+    $this->set('direction', $direction);
+    return $this;
   }
 
   /**

--- a/src/Entity/SmsMessageInterface.php
+++ b/src/Entity/SmsMessageInterface.php
@@ -14,26 +14,6 @@ use Drupal\Core\Entity\EntityInterface;
 interface SmsMessageInterface extends ContentEntityInterface, PlainSmsMessageInterface {
 
   /**
-   * Get direction of the message.
-   *
-   * @return int
-   *   See \Drupal\sms\Entity\SmsMessageInterface::DIRECTION_* constants for
-   *   potential values.
-   */
-  public function getDirection();
-
-  /**
-   * Set direction of the message.
-   *
-   * @param int $direction
-   *   Any of \Drupal\sms\Entity\SmsMessageInterface::DIRECTION_* constants
-   *
-   * @return $this
-   *   Return SMS message for chaining.
-   */
-  public function setDirection($direction);
-
-  /**
    * Gets the name of the sender of this SMS message.
    *
    * @return string|NULL

--- a/src/Message/SmsMessage.php
+++ b/src/Message/SmsMessage.php
@@ -48,6 +48,15 @@ class SmsMessage implements SmsMessageInterface {
   protected $gateway;
 
   /**
+   * The direction of the message.
+   *
+   * See \Drupal\sms\Direction constants for potential values.
+   *
+   * @var integer
+   */
+  protected $direction;
+
+  /**
    * @var string
    *   Other options to be used for the sms.
    */
@@ -176,6 +185,21 @@ class SmsMessage implements SmsMessageInterface {
    */
   public function setGateway(SmsGatewayInterface $gateway) {
     $this->gateway = $gateway;
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDirection() {
+    return $this->direction;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setDirection($direction) {
+    $this->direction = $direction;
     return $this;
   }
 

--- a/src/Message/SmsMessageInterface.php
+++ b/src/Message/SmsMessageInterface.php
@@ -138,6 +138,25 @@ interface SmsMessageInterface {
   public function setGateway(SmsGatewayInterface $gateway);
 
   /**
+   * Get direction of the message.
+   *
+   * @return int
+   *   See \Drupal\sms\Direction constants for potential values.
+   */
+  public function getDirection();
+
+  /**
+   * Set direction of the message.
+   *
+   * @param int $direction
+   *   Any of \Drupal\sms\Direction constants.
+   *
+   * @return $this
+   *   Return SMS message for chaining.
+   */
+  public function setDirection($direction);
+
+  /**
    * Gets the options for building or sending this SMS message.
    *
    * @return array

--- a/src/Provider/DefaultSmsProvider.php
+++ b/src/Provider/DefaultSmsProvider.php
@@ -67,7 +67,8 @@ class DefaultSmsProvider implements SmsProviderInterface {
   /**
    * {@inheritdoc}
    */
-  public function queue(SmsMessageEntityInterface $sms_message) {
+  public function queue(SmsMessageInterface $sms_message) {
+    $sms_message = SmsMessage::convertFromSmsMessage($sms_message);
     $sms_messages = $this->dispatch('sms.message.preprocess', [$sms_message]);
 
     /** @var SmsMessageEntityInterface[] $sms_messages */
@@ -95,24 +96,6 @@ class DefaultSmsProvider implements SmsProviderInterface {
     }
 
     return $this->dispatch('sms.message.postprocess', $sms_messages);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function queueIn(SmsMessageInterface $sms_message) {
-    $sms_message = SmsMessage::convertFromSmsMessage($sms_message)
-      ->setDirection(Direction::INCOMING);
-    $this->queue($sms_message);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function queueOut(SmsMessageInterface $sms_message) {
-    $sms_message = SmsMessage::convertFromSmsMessage($sms_message)
-      ->setDirection(Direction::OUTGOING);
-    $this->queue($sms_message);
   }
 
   /**

--- a/src/Provider/DefaultSmsProvider.php
+++ b/src/Provider/DefaultSmsProvider.php
@@ -68,7 +68,6 @@ class DefaultSmsProvider implements SmsProviderInterface {
    * {@inheritdoc}
    */
   public function queue(SmsMessageInterface $sms_message) {
-    $sms_message = SmsMessage::convertFromSmsMessage($sms_message);
     $sms_messages = $this->dispatch('sms.message.preprocess', [$sms_message]);
 
     /** @var SmsMessageEntityInterface[] $sms_messages */
@@ -76,7 +75,7 @@ class DefaultSmsProvider implements SmsProviderInterface {
       // Tag so 'sms.message.*process' are not dispatched again.
       $sms_message->setOption('_no_dispatch_events', TRUE);
 
-      if ($count = $sms_message->validate()->count()) {
+      if ($sms_message instanceof SmsMessageEntityInterface && ($count = $sms_message->validate()->count())) {
         throw new SmsException(sprintf('Can not queue SMS message because there are %s validation error(s).', $count));
       }
 
@@ -92,6 +91,7 @@ class DefaultSmsProvider implements SmsProviderInterface {
         continue;
       }
 
+      $sms_message = SmsMessage::convertFromSmsMessage($sms_message);
       $sms_message->save();
     }
 

--- a/src/Provider/PhoneNumberProvider.php
+++ b/src/Provider/PhoneNumberProvider.php
@@ -19,6 +19,7 @@ use Drupal\sms\Message\SmsMessage;
 use Drupal\Component\Utility\Random;
 use Drupal\sms\Exception\NoPhoneNumberException;
 use Drupal\Core\Entity\EntityStorageException;
+use Drupal\sms\Direction;
 
 /**
  * Phone number provider.
@@ -120,10 +121,11 @@ class PhoneNumberProvider implements PhoneNumberProviderInterface {
 
     $sms_message = SmsMessageEntity::convertFromSmsMessage($sms_message)
       ->addRecipient(reset($phone_numbers))
-      ->setRecipientEntity($entity);
+      ->setRecipientEntity($entity)
+      ->setDirection(Direction::OUTGOING);
 
     $this->smsProvider
-      ->queueOut($sms_message);
+      ->queue($sms_message);
   }
 
   /**
@@ -207,7 +209,8 @@ class PhoneNumberProvider implements PhoneNumberProviderInterface {
       $sms_message = new SmsMessage();
       $sms_message
         ->addRecipient($phone_number)
-        ->setMessage($message);
+        ->setMessage($message)
+        ->setDirection(Direction::OUTGOING);
 
       $data['sms-message'] = $sms_message;
       $data['sms_verification_code'] = $phone_verification->getCode();
@@ -217,7 +220,7 @@ class PhoneNumberProvider implements PhoneNumberProviderInterface {
         ->setAutomated(FALSE);
 
       $this->smsProvider
-        ->queueOut($sms_message);
+        ->queue($sms_message);
     }
 
     return $phone_verification;

--- a/src/Provider/SmsProviderInterface.php
+++ b/src/Provider/SmsProviderInterface.php
@@ -20,8 +20,8 @@ interface SmsProviderInterface {
   /**
    * Queue a SMS message for sending or receiving.
    *
-   * @param \Drupal\sms\Entity\SmsMessageInterface $sms_message
-   *   A SMS message entity.
+   * @param \Drupal\sms\Message\SmsMessageInterface $sms_message
+   *   A SMS message.
    *
    * @return \Drupal\sms\Entity\SmsMessageInterface[]
    *   The queued messages. A single message may be transformed into many.
@@ -29,27 +29,7 @@ interface SmsProviderInterface {
    * @throws \Drupal\sms\Exception\RecipientRouteException
    *   Thrown if no gateway could be determined for the message.
    */
-  public function queue(SmsMessageEntityInterface $sms_message);
-
-  /**
-   * Queue a standard SMS message for receiving.
-   *
-   * @todo Remove if standard message gets a direction property.
-   *
-   * @param \Drupal\sms\Message\SmsMessageInterface $sms_message
-   *   A standard SMS message.
-   */
-  public function queueIn(SmsMessageInterface $sms_message);
-
-  /**
-   * Queue a standard SMS message for sending.
-   *
-   * @todo Remove if standard message gets a direction property.
-   *
-   * @param \Drupal\sms\Message\SmsMessageInterface $sms_message
-   *   A standard SMS message.
-   */
-  public function queueOut(SmsMessageInterface $sms_message);
+  public function queue(SmsMessageInterface $sms_message);
 
   /**
    * Sends an SMS using the active gateway.

--- a/src/Tests/SmsFrameworkMessageTestTrait.php
+++ b/src/Tests/SmsFrameworkMessageTestTrait.php
@@ -7,6 +7,8 @@
 
 namespace Drupal\sms\Tests;
 
+use Drupal\sms\Direction;
+
 /**
  * SMS Message object test trait.
  *
@@ -129,6 +131,22 @@ trait SmsFrameworkMessageTestTrait {
     $sms_message
       ->removeRecipients(['123123123', '234234234']);
     $this->assertEquals(['456456456'], $sms_message->getRecipients());
+  }
+
+  /**
+   * Tests direction of SMS messages.
+   *
+   * @covers ::getDirection
+   * @covers ::setDirection
+   */
+  public function testDirection() {
+    $sms_message2 = $this->createSmsMessage()
+      ->setDirection(Direction::OUTGOING);
+    $this->assertEquals(Direction::OUTGOING, $sms_message2->getDirection());
+
+    $sms_message3 = $this->createSmsMessage()
+      ->setDirection(Direction::INCOMING);
+    $this->assertEquals(Direction::INCOMING, $sms_message3->getDirection());
   }
 
   /**

--- a/tests/src/Kernel/SmsFrameworkMessageEntityTest.php
+++ b/tests/src/Kernel/SmsFrameworkMessageEntityTest.php
@@ -99,23 +99,15 @@ class SmsFrameworkMessageEntityTest extends SmsFrameworkKernelBase {
   }
 
   /**
-   * Tests direction of SMS messages.
+   * Tests entity validation for direction property of SMS message entity.
    *
    * @covers ::getDirection
    * @covers ::setDirection
    */
-  public function testDirection() {
+  public function testDirectionEntityValidation() {
     // Check for validation violation for missing direction.
     $sms_message1 = $this->createSmsMessage();
     $this->assertTrue(in_array('direction', $sms_message1->validate()->getFieldNames()));
-
-    $sms_message2 = $this->createSmsMessage()
-      ->setDirection(Direction::OUTGOING);
-    $this->assertEquals(Direction::OUTGOING, $sms_message2->getDirection());
-
-    $sms_message3 = $this->createSmsMessage()
-      ->setDirection(Direction::INCOMING);
-    $this->assertEquals(Direction::INCOMING, $sms_message3->getDirection());
   }
 
   /**

--- a/tests/src/Kernel/SmsFrameworkProviderTest.php
+++ b/tests/src/Kernel/SmsFrameworkProviderTest.php
@@ -137,9 +137,11 @@ class SmsFrameworkProviderTest extends SmsFrameworkKernelBase {
     $sms_message = new StandardSmsMessage('', [], '', [], NULL);
     $sms_message
       ->addRecipients($this->randomPhoneNumbers())
-      ->setMessage($this->randomString());
+      ->setMessage($this->randomString())
+      ->setDirection(Direction::INCOMING);
 
-    $this->smsProvider->queueIn($sms_message);
+    $this->smsProvider
+      ->queue($sms_message);
 
     $sms_messages = SmsMessage::loadMultiple();
     $this->assertEquals(1, count($sms_messages), 'There is one SMS message in the queue.');
@@ -152,12 +154,13 @@ class SmsFrameworkProviderTest extends SmsFrameworkKernelBase {
    * Test sending standard SMS object queue out.
    */
   public function testQueueOut() {
-    $sms_message = new StandardSmsMessage('', [], '', [], NULL);
+    $sms_message = new StandardSmsMessage();
     $sms_message
       ->addRecipients($this->randomPhoneNumbers())
-      ->setMessage($this->randomString());
+      ->setMessage($this->randomString())
+      ->setDirection(Direction::OUTGOING);
 
-    $this->smsProvider->queueOut($sms_message);
+    $this->smsProvider->queue($sms_message);
 
     $sms_messages = SmsMessage::loadMultiple();
     $this->assertEquals(1, count($sms_messages), 'There is one SMS message in the queue.');
@@ -177,9 +180,10 @@ class SmsFrameworkProviderTest extends SmsFrameworkKernelBase {
     $sms_message = new StandardSmsMessage('', [], '', [], NULL);
     $sms_message
       ->addRecipients($this->randomPhoneNumbers())
-      ->setMessage($this->randomString());
+      ->setMessage($this->randomString())
+      ->setDirection(Direction::OUTGOING);
 
-    $this->smsProvider->queueOut($sms_message);
+    $this->smsProvider->queue($sms_message);
     $this->assertEquals(1, count($this->getTestMessages($this->gateway)), 'One standard SMS send skipped queue.');
   }
 

--- a/tests/src/Kernel/SmsFrameworkSmsSendTest.php
+++ b/tests/src/Kernel/SmsFrameworkSmsSendTest.php
@@ -10,6 +10,7 @@ namespace Drupal\Tests\sms\Kernel;
 use Drupal\sms\Entity\SmsGateway;
 use Drupal\sms\Message\SmsMessage;
 use Drupal\sms\Message\SmsMessageResultInterface;
+use Drupal\sms\Direction;
 
 /**
  * Tests sending SMS messages.
@@ -70,8 +71,9 @@ class SmsFrameworkSmsSendTest extends SmsFrameworkKernelBase {
 
         $sms_message = (new SmsMessage())
           ->addRecipients($this->randomPhoneNumbers(1))
-          ->setMessage($this->randomString());
-        $this->defaultSmsProvider->queueOut($sms_message);
+          ->setMessage($this->randomString())
+          ->setDirection(Direction::OUTGOING);
+        $this->defaultSmsProvider->queue($sms_message);
 
         $message_counts[$i]++;
         foreach ($gateways as $k => $gateway2) {


### PR DESCRIPTION
- Removing queueIn
- Removing queueOut
- Allowing standard messages on queue(), not just entity.
- Promoted set/getDirection from message entity to common method.
- Promoted direction tests to message trait, which enables coverage on both message classes.
