### PR TITLE
Entity cannot be referenced validation failures for SMS message recipient_entity field

### DIFF
--- a/modules/sms_blast/src/Tests/SmsBlastWebTest.php
+++ b/modules/sms_blast/src/Tests/SmsBlastWebTest.php
@@ -75,6 +75,7 @@ class SmsBlastWebTest extends SmsFrameworkWebTestBase {
 
     // Verify three of the users randomly.
     $numbers = range(0, count($entities) - 1);
+    shuffle($numbers);
     foreach (array_slice($numbers, 0, 3) as $i) {
       $this->verifyPhoneNumber($entities[$i], $phone_numbers[0]);
     }

--- a/modules/sms_blast/src/Tests/SmsBlastWebTest.php
+++ b/modules/sms_blast/src/Tests/SmsBlastWebTest.php
@@ -60,16 +60,27 @@ class SmsBlastWebTest extends SmsFrameworkWebTestBase {
    * Tests sending SMS blast.
    */
   public function testSendBlast() {
-    // Create users with two phone numbers. Only one message should be sent to
-    // each user.
-    $phone_numbers = ['+123123123', '+456456456'];
-    for ($i = 0; $i < 3; $i++) {
-      // Create an unverified user.
-      $this->createEntityWithPhoneNumber($this->phoneNumberSettings, $phone_numbers);
-      // Create a verified user.
-      $entity = $this->createEntityWithPhoneNumber($this->phoneNumberSettings, $phone_numbers);
-      $this->verifyPhoneNumber($entity, $phone_numbers[0]);
+    // Create users with multiple phone numbers. Only one message should be sent
+    // to each user.
+    $phone_numbers = $this->randomPhoneNumbers();
+    $entities = [];
+    for ($i = 0; $i < 6; $i++) {
+      /** @var \Drupal\user\UserInterface $user */
+      $user = $this->createEntityWithPhoneNumber($this->phoneNumberSettings, $phone_numbers);
+      // Need to activate so when DER does entity validation it is included by the
+      // UserSelection plugin.
+      $user->activate()->save();
+      $entities[] = $user;
     }
+
+    // Verify three of the users randomly.
+    $numbers = range(0, count($entities) - 1);
+    foreach (array_slice($numbers, 0, 3) as $i) {
+      $this->verifyPhoneNumber($entities[$i], $phone_numbers[0]);
+    }
+
+    // Reset messages created as a result of creating entities above. Such as
+    // verification messages.
     $this->resetTestMessages();
 
     $edit['message'] = $this->randomString();

--- a/modules/sms_user/tests/src/Kernel/SmsFrameworkUserActiveHoursServiceTest.php
+++ b/modules/sms_user/tests/src/Kernel/SmsFrameworkUserActiveHoursServiceTest.php
@@ -295,6 +295,11 @@ class SmsFrameworkUserActiveHoursServiceTest extends SmsFrameworkKernelBase {
       'uid' => 1,
       'name' => $this->randomMachineName(),
     ] + $values);
+
+    // Need to activate so when DER does entity validation it is included by the
+    // UserSelection plugin.
+    $user->activate();
+
     $user->save();
     return $user;
   }

--- a/src/Entity/SmsMessage.php
+++ b/src/Entity/SmsMessage.php
@@ -433,11 +433,7 @@ class SmsMessage extends ContentEntityBase implements SmsMessageInterface {
     $fields['sender_entity'] = BaseFieldDefinition::create('dynamic_entity_reference')
       ->setLabel(t('Sender entity'))
       ->setDescription(t('The entity who sent the SMS message.'))
-      ->setRequired(FALSE)
-      ->setSettings([
-        'exclude_entity_types' => TRUE,
-        'entity_type_ids' => [],
-      ]);
+      ->setRequired(FALSE);
 
     $fields['recipient_phone_number'] = BaseFieldDefinition::create('telephone')
       ->setLabel(t('Recipient phone number'))
@@ -448,11 +444,7 @@ class SmsMessage extends ContentEntityBase implements SmsMessageInterface {
     $fields['recipient_entity'] = BaseFieldDefinition::create('dynamic_entity_reference')
       ->setLabel(t('Recipient entity'))
       ->setDescription(t('The entity who received the SMS message.'))
-      ->setRequired(FALSE)
-      ->setSettings([
-        'exclude_entity_types' => TRUE,
-        'entity_type_ids' => [],
-      ]);
+      ->setRequired(FALSE);
 
     // Meta information.
     $fields['options'] = BaseFieldDefinition::create('map')

--- a/src/Entity/SmsMessage.php
+++ b/src/Entity/SmsMessage.php
@@ -433,7 +433,11 @@ class SmsMessage extends ContentEntityBase implements SmsMessageInterface {
     $fields['sender_entity'] = BaseFieldDefinition::create('dynamic_entity_reference')
       ->setLabel(t('Sender entity'))
       ->setDescription(t('The entity who sent the SMS message.'))
-      ->setRequired(FALSE);
+      ->setRequired(FALSE)
+      ->setSettings([
+        'exclude_entity_types' => TRUE,
+        'entity_type_ids' => [],
+      ]);
 
     $fields['recipient_phone_number'] = BaseFieldDefinition::create('telephone')
       ->setLabel(t('Recipient phone number'))
@@ -444,7 +448,11 @@ class SmsMessage extends ContentEntityBase implements SmsMessageInterface {
     $fields['recipient_entity'] = BaseFieldDefinition::create('dynamic_entity_reference')
       ->setLabel(t('Recipient entity'))
       ->setDescription(t('The entity who received the SMS message.'))
-      ->setRequired(FALSE);
+      ->setRequired(FALSE)
+      ->setSettings([
+        'exclude_entity_types' => TRUE,
+        'entity_type_ids' => [],
+      ]);
 
     // Meta information.
     $fields['options'] = BaseFieldDefinition::create('map')


### PR DESCRIPTION
- [Entity validation errors from DER base fields](https://www.drupal.org/node/2829049)
- [Entity cannot be referenced validation failures for SMS message recipient_entity field](https://www.drupal.org/node/2829041)